### PR TITLE
use spring boot starter parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.0.4</version>
+    <relativePath/> 
+  </parent>
+
   <groupId>com.infosys.openbanking</groupId>
   <artifactId>consent-management</artifactId>
   <version>1.0-SNAPSHOT</version>
@@ -66,9 +73,6 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>reference.conf</resource>
-                </transformer>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>${mainClass}</mainClass>
                 </transformer>
               </transformers>
             </configuration>


### PR DESCRIPTION
The issue was related with how the shading plugin was working. 

We are now using spring-starter and it seems that it needs to uberjar build in a given way. Our shading configuration was messing up with it. 

This PR will fix it for now. I will fix it in Kalix and it will be part of release 1.2.0.